### PR TITLE
将FileProvider改为继承它的TakephotoFileProvider,防止集成后与项目中已存在的FileProvide冲突

### DIFF
--- a/takephoto_library/src/main/AndroidManifest.xml
+++ b/takephoto_library/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <application android:allowBackup="true">
         <activity android:name="com.soundcloud.android.crop.CropImageActivity" />
         <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name=".provider.TakePhotoFileProvider"
             android:authorities="${applicationId}.fileprovider"
             android:grantUriPermissions="true"
             android:exported="false">

--- a/takephoto_library/src/main/java/org/devio/takephoto/provider/TakePhotoFileProvider.java
+++ b/takephoto_library/src/main/java/org/devio/takephoto/provider/TakePhotoFileProvider.java
@@ -1,0 +1,10 @@
+package org.devio.takephoto.provider;
+
+import android.support.v4.content.FileProvider;
+
+/**
+ * Created by moos on 2018/4/13.
+ */
+
+public class TakePhotoFileProvider extends FileProvider {
+}


### PR DESCRIPTION
由于Manifest文件中注册的是默认的FileProvider，可能会与开发者已有项目中的FileProvider产生冲突，导致如下问题：
```
Error:Execution failed for task ':app:processArmDebugManifest'. Manifest merger failed with multiple errors, see logs.
```
因此，写了一个TakePhotoFileProvider继承自FileProvider，同时library中使用TakephotoFileprovider可以解决该问题。